### PR TITLE
DM-9599: Support concatenation of Transforms

### DIFF
--- a/include/astshim.h
+++ b/include/astshim.h
@@ -11,6 +11,7 @@
 #include "astshim/Mapping.h"
 #include "astshim/Frame.h"
 #include "astshim/FrameSet.h"
+#include "astshim/functional.h"
 
 // channels
 #include "astshim/FitsChan.h"

--- a/include/astshim/base.h
+++ b/include/astshim/base.h
@@ -32,6 +32,8 @@ extern "C" {
   #include "ast.h"
 }
 
+// Do not delete this or free functions and enums will not be documented
+/// AST wrapper classes and functions.
 namespace ast {
 
 /**

--- a/include/astshim/base.h
+++ b/include/astshim/base.h
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2016  AURA/LSST.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,14 +9,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 #ifndef ASTSHIM_BASE_H
@@ -29,7 +29,7 @@
 #include "ndarray.h"
 
 extern "C" {
-  #include "ast.h"
+#include "ast.h"
 }
 
 // Do not delete this or free functions and enums will not be documented
@@ -41,10 +41,10 @@ Exception thrown when a search is unsuccessful.
 
 Thrown by Frame.convert and Frame.findFrame
 */
-class notfound_error: public std::runtime_error {
+class notfound_error : public std::runtime_error {
 public:
     /// Construct a notfound_error with a specified error message
-    notfound_error(std::string const & msg) : std::runtime_error(msg) {};
+    notfound_error(std::string const &msg) : std::runtime_error(msg){};
 };
 
 using Array2D = ndarray::Array<double, 2, 2>;
@@ -89,7 +89,7 @@ Throw std::runtime_error if AST's state is bad
 @note on the first call an error handler is registered
 that saves error messages to a buffer.
 */
-void assertOK(AstObject * rawPtr1=nullptr, AstObject * rawPtr2=nullptr);
+void assertOK(AstObject *rawPtr1 = nullptr, AstObject *rawPtr2 = nullptr);
 
 /**
 Control whether graphical escape sequences are included in strings.
@@ -121,7 +121,7 @@ can be changed using this function.
 - Unlike the AST function `astEscapes`, this function will not attempt to execute
     if an error has already occurred.
 */
-inline bool escapes(int include=-1) {
+inline bool escapes(int include = -1) {
     assertOK();
     int ret = astEscapes(include);
     assertOK();

--- a/include/astshim/functional.h
+++ b/include/astshim/functional.h
@@ -1,0 +1,65 @@
+/*
+ * LSST Data Management System
+ * Copyright 2017 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef ASTSHIM_FUNCTIONAL_H
+#define ASTSHIM_FUNCTIONAL_H
+
+#include "astshim/FrameSet.h"
+
+/*
+ * This header declares operations that treat ast objects (particularly Mapping
+ * and its subclasses) as functions to be manipulated.
+ */
+namespace ast {
+
+/**
+ * Construct a FrameSet that performs two transformations in series.
+ *
+ * When used as a Mapping, the FrameSet shall apply `first`, followed by
+ * `second`. Its inverse shall apply the inverse of `second`, followed by the
+ * inverse of `first`. The concatenation is only valid if `first.getCurrent()`
+ * and `second.getBase()` have the same number of axes.
+ *
+ * The new FrameSet shall contain all Frames and Mappings from `first`,
+ * followed by all Frames and Mappings from `second`, preserving their
+ * original order. The current frame of `first` shall be connected to the base
+ * frame of `second` by a UnitMap. The new set's base frame shall be the base
+ * frame of `first`, and its current frame shall be the current frame of `second`.
+ *
+ * The FrameSet shall be independent of the input arguments, so changes to the
+ * original FrameSets (in particular, reassignments of their base or current
+ * frames) shall not affect it.
+ *
+ * @param second, first the FrameSets to concatenate. The operations are given
+ *                      in right-to-left order for consistency with, e.g.,
+ *                      Mapping::of.
+ * @return a pointer to a combined FrameSet as described above
+ *
+ * Example: if `first` has 3 frames and `second `has 4, then the result shall
+ *          contain 7 frames, of which frames 1-3 are the same as frames 1-3 of
+ *          `first`, in order, and merged frames `4-7` are the same as frames
+ *          1-4 of `second`, in order.
+ */
+std::shared_ptr<FrameSet> prepend(FrameSet const& second, FrameSet const& first);
+
+}  // namespace ast
+
+#endif  // ASTSHIM_FUNCTIONAL_H

--- a/python/astshim/SConscript
+++ b/python/astshim/SConscript
@@ -13,6 +13,7 @@ scripts.BasicSConscript.pybind11([
     "mapBox",
     "mapSplit",
     "quadApprox",
+    "functional",
 
     "fitsChan",
     "xmlChan",

--- a/python/astshim/__init__.py
+++ b/python/astshim/__init__.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the LSST License Statement and
 # the GNU General Public License along with this program.  If not,
 # see <https://www.lsstcorp.org/LegalNotices/>.
-#/
+#
 
 """lsst.astshim
 """
@@ -35,6 +35,7 @@ from .keyMap import *
 from .mapBox import *
 from .mapSplit import *
 from .quadApprox import *
+from .functional import *
 # channels
 from .fitsChan import *
 from .xmlChan import *

--- a/python/astshim/functional.cc
+++ b/python/astshim/functional.cc
@@ -1,0 +1,43 @@
+/*
+ * LSST Data Management System
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ * See the COPYRIGHT file
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+#include "astshim/functional.h"
+
+namespace ast {
+namespace {
+
+PYBIND11_PLUGIN(functional) {
+    py::module mod("functional");
+
+    py::module::import("astshim.frameSet");
+
+    mod.def("prepend", &prepend, "second"_a, "first"_a);
+
+    return mod.ptr();
+}
+
+}  // <anonymous>
+}  // ast

--- a/src/functional.cc
+++ b/src/functional.cc
@@ -1,0 +1,43 @@
+/*
+ * LSST Data Management System
+ * Copyright 2017 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include "astshim/functional.h"
+#include "astshim/UnitMap.h"
+
+namespace ast {
+
+std::shared_ptr<FrameSet> prepend(FrameSet const& second, FrameSet const& first) {
+    std::shared_ptr<FrameSet> const merged = first.copy();
+    std::shared_ptr<FrameSet> const newFrames = second.copy();
+
+    newFrames->setCurrent(FrameSet::BASE);
+    int const joinNaxes = first.getFrame(FrameSet::CURRENT)->getNaxes();
+    merged->addFrame(FrameSet::CURRENT, UnitMap(joinNaxes), *newFrames);
+
+    // All frame numbers from `second` have been offset in `merged` by number of frames in `first`
+    int const mergedCurrent = first.getNframe() + second.getCurrent();
+    merged->setCurrent(mergedCurrent);
+
+    return merged;
+}
+
+}  // namespace ast

--- a/tests/test_prepend.py
+++ b/tests/test_prepend.py
@@ -1,0 +1,147 @@
+from __future__ import absolute_import, division, print_function
+import unittest
+from numpy.testing import assert_allclose
+
+from astshim import Frame, SkyFrame, UnitMap, FrameSet, prepend
+from astshim.test import makeForwardPolyMap, makeTwoWayPolyMap
+
+
+class TestFrameSetPrepend(unittest.TestCase):
+
+    def makeFrameSet(self, nIn, nOut):
+        """Create a FrameSet with the specified dimensions.
+
+        The FrameSet shall have the following Frames:
+              "base"(nIn, #1)
+                    |
+                    +--------------
+                    |             |
+               "mid"(4, #2)  "fork"(1, #4)
+                    |
+            "current"(nOut, #3)
+        """
+        frameSet = FrameSet(Frame(nIn, "Ident=base"))
+        frameSet.addFrame(FrameSet.CURRENT,
+                          makeTwoWayPolyMap(nIn, 4),
+                          Frame(4, "Ident=mid"))
+        frameSet.addFrame(FrameSet.CURRENT,
+                          makeTwoWayPolyMap(4, nOut),
+                          Frame(nOut, "Ident=current"))
+        frameSet.addFrame(FrameSet.BASE,
+                          makeTwoWayPolyMap(nIn, 1),
+                          Frame(1, "Ident=fork"))
+
+        frameSet.setCurrent(3)
+        assert frameSet.getNframe() == 4
+        assert frameSet.getBase() == 1
+        assert frameSet.getFrame(FrameSet.BASE).getIdent() == "base"
+        assert frameSet.getFrame(2).getIdent() == "mid"
+        assert frameSet.getCurrent() == 3
+        assert frameSet.getFrame(FrameSet.CURRENT).getIdent() == "current"
+        assert frameSet.getFrame(4).getIdent() == "fork"
+        return frameSet
+
+    def test_PrependEffect(self):
+        """Check that a concatenated FrameSet transforms correctly.
+        """
+        set1 = self.makeFrameSet(2, 3)
+        set2 = self.makeFrameSet(3, 1)
+        set12 = prepend(set2, set1)
+
+        # Can't match 1D output to 2D input
+        with self.assertRaises(RuntimeError):
+            prepend(set1, set2)
+
+        x = [1.2, 3.4]
+        y_merged = set12.tranForward(x)
+        y_separate = set2.tranForward(set1.tranForward(x))
+        assert_allclose(y_merged, y_separate)
+
+        y = [-0.3]
+        x_merged = set12.tranInverse(y)
+        x_separate = set1.tranInverse(set2.tranInverse(y))
+        assert_allclose(x_merged, x_separate)
+
+        # No side effects
+        self.assertEqual(set1.getBase(), 1)
+        self.assertEqual(set1.getCurrent(), 3)
+        self.assertEqual(set2.getBase(), 1)
+        self.assertEqual(set2.getCurrent(), 3)
+
+    def test_PrependFrames(self):
+        """Check that a concatenated FrameSet preserves all Frames.
+        """
+        set1 = self.makeFrameSet(1, 3)
+        # AST docs say FrameSets always have contiguously numbered frames,
+        # but let's make sure
+        set1.removeFrame(2)
+        set2 = self.makeFrameSet(3, 2)
+        set12 = prepend(set2, set1)
+
+        self.assertEquals(set1.getNframe() + set2.getNframe(),
+                          set12.getNframe())
+        for i in range(1, 1+set1.getNframe()):
+            oldFrame = set1.getFrame(i)
+            newFrame = set12.getFrame(i)
+            self.assertEquals(oldFrame.getIdent(), newFrame.getIdent())
+            self.assertEquals(oldFrame.getNaxes(), newFrame.getNaxes())
+            if i == set1.getBase():
+                self.assertTrue(i == set12.getBase())
+            else:
+                self.assertFalse(i == set12.getBase())
+        for i in range(1, 1+set2.getNframe()):
+            offset = set1.getNframe()
+            oldFrame = set2.getFrame(i)
+            newFrame = set12.getFrame(offset + i)
+            self.assertEquals(oldFrame.getIdent(), newFrame.getIdent())
+            self.assertEquals(oldFrame.getNaxes(), newFrame.getNaxes())
+            if i == set2.getCurrent():
+                self.assertTrue(offset + i == set12.getCurrent())
+            else:
+                self.assertFalse(offset + i == set12.getCurrent())
+
+    def test_PrependIndependent(self):
+        """Check that a concatenated FrameSet is not affected by changes
+        to its constituents.
+        """
+        set1 = self.makeFrameSet(3, 3)
+        set2 = self.makeFrameSet(3, 3)
+        set12 = prepend(set2, set1)
+
+        nTotal = set12.getNframe()
+        x = [1.2, 3.4, 5.6]
+        y = set12.tranForward(x)
+
+        set1.addFrame(2, makeTwoWayPolyMap(4, 2), Frame(2, "Ident=extra"))
+        set1.addFrame(1, makeTwoWayPolyMap(3, 3), Frame(3, "Ident=legume"))
+        set1.removeFrame(3)
+        set2.addFrame(4, makeForwardPolyMap(1, 4), Frame(4, "Ident=extra"))
+        set2.setBase(2)
+
+        # Use exact equality because nothing should change
+        self.assertEquals(set12.getNframe(), nTotal)
+        self.assertEquals(set12.tranForward(x), y)
+
+    def test_PrependMismatch(self):
+        """Check that prepend behaves as expected when joining non-identical frames.
+        """
+        set1 = self.makeFrameSet(3, 2)
+        set2 = self.makeFrameSet(2, 3)
+        set1.addFrame(FrameSet.CURRENT, makeForwardPolyMap(2, 2),
+                      SkyFrame("Ident=sky"))
+        set12 = prepend(set2, set1)
+
+        x = [1.2, 3.4, 5.6]
+        y_merged = set12.tranForward(x)
+        y_separate = set2.tranForward(set1.tranForward(x))
+        assert_allclose(y_merged, y_separate)
+
+        iFrom = set1.getCurrent()
+        iTo = set1.getNframe() + set2.getBase()
+        self.assertIsInstance(set12.getFrame(iFrom), SkyFrame)
+        self.assertNotIsInstance(set12.getFrame(iTo), SkyFrame)
+        self.assertIsInstance(set12.getMapping(iFrom, iTo), UnitMap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a top-level function that concatenates FrameSets (in the sense of `Mapping::of`, but preserving all Frames). The function has been added to a new subpackage (`functional.h`) that may later grow to include other, similar operations on Mappings and FrameSets.

This PR also includes some new test code and some formatting fixes.