### PR TITLE
DM-10764: Rename `Transform::of(first)` and `Mapping::of(first)` to `then(next)`

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -28,9 +28,9 @@ that support time, spectra and tables have yet been wrapped. The python wrapper 
     - New classes @ref SeriesMap and @ref ParallelMap are subclasses of @ref CmpMap
         and any compound mapping will always be an instance of one or the other of these subclasses.
         Thus `Object.getClassName` returns "SeriesMap" or "ParallelMap" for all compound maps.
-    - Added @ref Mapping.of as a convenient way to make a @ref SeriesMap
-        and @ref Mapping.over as a convient way to make a @ref ParallelMap.
-    - Added @ref Frame.over as a convenient way to make a @ref CmpFrame.
+    - Added @ref Mapping.then as a convenient way to make a @ref SeriesMap
+        and @ref Mapping.under as a convenient way to make a @ref ParallelMap.
+    - Added @ref Frame.under as a convenient way to make a @ref CmpFrame.
     - Instead of wrapping `astDecompose`:
         - Call CmpMap.operator[] to retrieve a mapping from a compound mapping.
         - Call @ref CmpMap.getSeries to find out if a compound mapping is in series.

--- a/examples/basics.cc
+++ b/examples/basics.cc
@@ -54,7 +54,7 @@ int main() {
     std::vector<double> shift = {1.5, -0.1};
     auto shiftMap = ast::ShiftMap(shift);
 
-    auto seriesMap = zoomMap.of(shiftMap);
+    auto seriesMap = shiftMap.then(zoomMap);
     seriesMap.tranForward(from, to);
     std::cout << "\n\nx =" << from << std::endl;
     shiftMap.tranForward(from, to);

--- a/include/astshim/Frame.h
+++ b/include/astshim/Frame.h
@@ -990,13 +990,13 @@ public:
     }
 
     /**
-    Combine this frame with another to form a compound frame (CmpFrame)
+    Combine this frame with another to form a compound frame (CmpFrame),
+    with the axes of this frame followed by the axes of the `next` frame.
 
     A compound frame allows two component Frames
     (of any class) to be merged together to form a more complex
     Frame. The axes of the two component Frames then appear together
-    in the resulting CmpFrame (those of the first Frame, followed by
-    those of the this Frame).
+    in the resulting CmpFrame (those of this Frame, followed by those of `next`).
 
     Since a CmpFrame is itself a Frame, it can be used as a
     component in forming further CmpFrames. Frames of arbitrary
@@ -1011,10 +1011,13 @@ public:
     Thus input axis values corresponding to positions which are outside the
     Region will result in bad output axis values.
 
-    @param[in] first  The first frame in the compound frame (axes 1 - first.getNAxes())
+    The name comes the way vectors are sometimes shown for matrix multiplication:
+    vertically, with the first axis at the bottom and the last axis at the top.
+
+    @param[in]  next  The next frame in the compound frame (the final next.getNAxes() axes)
     @return a new CmpFrame
     */
-    CmpFrame over(Frame const &first) const;
+    CmpFrame under(Frame const &next) const;
 
     /**
     Normalise a set of Frame coordinate values which might be unsuitable for display

--- a/include/astshim/Mapping.h
+++ b/include/astshim/Mapping.h
@@ -165,24 +165,27 @@ public:
     /**
     Return a series compound mapping this(first(input)).
 
-    @param[in] first  the mapping whose output is the input of this mapping
+    @param[in] next  the mapping whose input is the output of this mapping
 
-    @throws std::invalid_argument if the number of output axes of `first` does not match
-        the number of input axes of this mapping.
+    @throws std::invalid_argument if the number of input axes of `next` does not match
+        the number of output axes of this mapping.
     */
-    SeriesMap of(Mapping const &first) const;
+    SeriesMap then(Mapping const &next) const;
 
     /**
     Return a parallel compound mapping
 
-    The resulting mapping has first.getNIn() + this.getNIn() inputs and next.getNOut() + this.getNOut()
-    outputs. The first getNIn() axes of input are transformed by the `first` mapping, producing the
-    first getNOut() axes of the output. The remaining axes of input are processed by this mapping,
-    resulting in the remaining axes of output.
+    The resulting mapping has `getNIn() + next.getNIn()` inputs and `getNOut() + next.getNOut()` outputs.
+    The first `getNIn()` axes of input are transformed by this mapping, producing the first `getNOut()` axes
+    of output. The remaining axes of input are processed by `next`, resulting in the remaining axes of output.
 
-    @param[in] first  the mapping that processes axes 1 through `first.getNIn()`
+    The name comes the way vectors are sometimes shown for matrix multiplication:
+    vertically, with the first axis at the bottom and the last axis at the top.
+
+    @param[in] next  the mapping that processes the final `next.getNin()` axes of input to produce
+    the final `next.getNout()` axes of output.
     */
-    ParallelMap over(Mapping const &first) const;
+    ParallelMap under(Mapping const &next) const;
 
     /**
     Evaluate the rate of change of the Mapping with respect to a specified input, at a specified position.

--- a/include/astshim/ParallelMap.h
+++ b/include/astshim/ParallelMap.h
@@ -54,7 +54,7 @@ public:
     /**
     Construct a ParallelMap
 
-    It may be clearer to constuct a @ref ParallelMap using @ref Mapping.over.
+    It may be clearer to constuct a @ref ParallelMap using @ref Mapping.under.
 
     @param[in] map1  The first mapping, which transforms the lower numbered coordinates/
     @param[in] map2  The second mapping.

--- a/include/astshim/SeriesMap.h
+++ b/include/astshim/SeriesMap.h
@@ -54,7 +54,7 @@ public:
     /**
     Construct a SeriesMap.
 
-    It may be clearer to construct a @ref SeriesMap using @ref Mapping.of.
+    It may be clearer to construct a @ref SeriesMap using @ref Mapping.then.
 
     @param[in] map1  The first mapping, which transforms input points.
     @param[in] map2  The second mapping, which transforms the output of the first mapping.

--- a/include/astshim/functional.h
+++ b/include/astshim/functional.h
@@ -48,17 +48,15 @@ namespace ast {
  * original FrameSets (in particular, reassignments of their base or current
  * frames) shall not affect it.
  *
- * @param second, first the FrameSets to concatenate. The operations are given
- *                      in right-to-left order for consistency with, e.g.,
- *                      Mapping::of.
+ * @param first, second the FrameSets to concatenate.
  * @return a pointer to a combined FrameSet as described above
  *
  * Example: if `first` has 3 frames and `second `has 4, then the result shall
  *          contain 7 frames, of which frames 1-3 are the same as frames 1-3 of
- *          `first`, in order, and merged frames `4-7` are the same as frames
+ *          `first`, in order, and frames 4-7 are the same as frames
  *          1-4 of `second`, in order.
  */
-std::shared_ptr<FrameSet> prepend(FrameSet const& second, FrameSet const& first);
+std::shared_ptr<FrameSet> append(FrameSet const& first, FrameSet const& second);
 
 }  // namespace ast
 

--- a/python/astshim/frame.cc
+++ b/python/astshim/frame.cc
@@ -126,7 +126,7 @@ PYBIND11_PLUGIN(frame) {
     cls.def("getUnit", &Frame::getUnit, "axis"_a);
     cls.def("intersect", &Frame::intersect, "a1"_a, "a2"_a, "b1"_a, "b2"_a);
     cls.def("matchAxes", &Frame::matchAxes, "other"_a);
-    cls.def("over", &Frame::over, "first"_a);
+    cls.def("under", &Frame::under, "next"_a);
     cls.def("norm", &Frame::norm, "value"_a);
     cls.def("offset", &Frame::offset, "point1"_a, "point2"_a, "offset"_a);
     cls.def("offset2", &Frame::offset2, "point1"_a, "angle"_a, "offset"_a);

--- a/python/astshim/functional.cc
+++ b/python/astshim/functional.cc
@@ -34,7 +34,7 @@ PYBIND11_PLUGIN(functional) {
 
     py::module::import("astshim.frameSet");
 
-    mod.def("prepend", &prepend, "second"_a, "first"_a);
+    mod.def("append", &append, "first"_a, "second"_a);
 
     return mod.ptr();
 }

--- a/python/astshim/mapping.cc
+++ b/python/astshim/mapping.cc
@@ -63,8 +63,8 @@ PYBIND11_PLUGIN(mapping) {
     cls.def("copy", &Mapping::copy);
     cls.def("getInverse", &Mapping::getInverse);
     cls.def("linearApprox", &Mapping::linearApprox, "lbnd"_a, "ubnd"_a, "tol"_a);
-    cls.def("of", &Mapping::of, "first"_a);
-    cls.def("over", &Mapping::over, "first"_a);
+    cls.def("then", &Mapping::then, "next"_a);
+    cls.def("under", &Mapping::under, "next"_a);
     cls.def("rate", &Mapping::rate, "at"_a, "ax1"_a, "ax2"_a);
     cls.def("simplify", &Mapping::simplify);
     // wrap the overloads of tranForward, tranInverse, tranGridForward and tranGridInverse that return a new

--- a/python/astshim/test.py
+++ b/python/astshim/test.py
@@ -86,8 +86,8 @@ class MappingTestCase(ObjectTestCase):
         rt2_poslist = amapinv.tranForward(to_poslist)
         assert_allclose(poslist, rt2_poslist, rtol=rtol, atol=atol)
 
-        # forward and inverse with a compound map of amap.getInverse().of(amap)
-        acmp = amapinv.of(amap)
+        # forward and inverse with a compound map of amap.then(amap.getInverse())
+        acmp = amap.then(amapinv)
         assert_allclose(poslist, acmp.tranForward(poslist), rtol=rtol, atol=atol)
 
         # test vector versions of forward and inverse
@@ -108,7 +108,7 @@ class MappingTestCase(ObjectTestCase):
         - A compound mapping of a amap and a unit amap simplifies to the original amap
         """
         amapinv = amap.getInverse()
-        cmp1 = amapinv.of(amap)
+        cmp1 = amap.then(amapinv)
         unit1 = cmp1.simplify()
         self.assertEqual(unit1.className, "UnitMap")
         self.assertEqual(amap.nIn, cmp1.nIn)
@@ -116,7 +116,7 @@ class MappingTestCase(ObjectTestCase):
         self.assertEqual(cmp1.nIn, unit1.nIn)
         self.assertEqual(cmp1.nOut, unit1.nOut)
 
-        cmp2 = amap.of(amapinv)
+        cmp2 = amapinv.then(amap)
         unit2 = cmp2.simplify()
         self.assertEqual(unit2.className, "UnitMap")
         self.assertEqual(amapinv.nIn, cmp2.nIn)
@@ -130,7 +130,7 @@ class MappingTestCase(ObjectTestCase):
             (unit2, amapinv, amapinv),
             (amapinv, unit1, amapinv),
         ):
-            cmp3 = mb.of(ma)
+            cmp3 = ma.then(mb)
             cmp3simp = cmp3.simplify()
             self.assertEqual(cmp3simp.className, amap.simplify().className)
             self.assertEqual(ma.nIn, cmp3.nIn)

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -63,7 +63,7 @@ std::vector<double> Frame::intersect(std::vector<double> const &a1, std::vector<
     return ret;
 }
 
-CmpFrame Frame::over(Frame const &first) const { return CmpFrame(first, *this); }
+CmpFrame Frame::under(Frame const &next) const { return CmpFrame(*this, next); }
 
 FrameMapping Frame::pickAxes(std::vector<int> const &axes) const {
     AstMapping *rawMap;

--- a/src/Mapping.cc
+++ b/src/Mapping.cc
@@ -34,9 +34,9 @@
 
 namespace ast {
 
-SeriesMap Mapping::of(Mapping const &first) const { return SeriesMap(first, *this); }
+SeriesMap Mapping::then(Mapping const &next) const { return SeriesMap(*this, next); }
 
-ParallelMap Mapping::over(Mapping const &first) const { return ParallelMap(first, *this); }
+ParallelMap Mapping::under(Mapping const &next) const { return ParallelMap(*this, next); }
 
 std::shared_ptr<Mapping> Mapping::getInverse() const {
     auto rawCopy = reinterpret_cast<AstMapping *>(astCopy(getRawPtr()));

--- a/src/functional.cc
+++ b/src/functional.cc
@@ -25,7 +25,7 @@
 
 namespace ast {
 
-std::shared_ptr<FrameSet> prepend(FrameSet const& second, FrameSet const& first) {
+std::shared_ptr<FrameSet> append(FrameSet const& first, FrameSet const& second) {
     std::shared_ptr<FrameSet> const merged = first.copy();
     std::shared_ptr<FrameSet> const newFrames = second.copy();
 

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, division, print_function
 import unittest
 from numpy.testing import assert_allclose
 
-from astshim import Frame, SkyFrame, UnitMap, FrameSet, prepend
+from astshim import Frame, SkyFrame, UnitMap, FrameSet, append
 from astshim.test import makeForwardPolyMap, makeTwoWayPolyMap
 
 
-class TestFrameSetPrepend(unittest.TestCase):
+class TestFrameSetAppend(unittest.TestCase):
 
     def makeFrameSet(self, nIn, nOut):
         """Create a FrameSet with the specified dimensions.
@@ -41,16 +41,16 @@ class TestFrameSetPrepend(unittest.TestCase):
         assert frameSet.getFrame(4).ident == "fork"
         return frameSet
 
-    def test_PrependEffect(self):
+    def test_AppendEffect(self):
         """Check that a concatenated FrameSet transforms correctly.
         """
         set1 = self.makeFrameSet(2, 3)
         set2 = self.makeFrameSet(3, 1)
-        set12 = prepend(set2, set1)
+        set12 = append(set1, set2)
 
         # Can't match 1D output to 2D input
         with self.assertRaises(RuntimeError):
-            prepend(set1, set2)
+            append(set2, set1)
 
         x = [1.2, 3.4]
         y_merged = set12.tranForward(x)
@@ -68,7 +68,7 @@ class TestFrameSetPrepend(unittest.TestCase):
         self.assertEqual(set2.base, 1)
         self.assertEqual(set2.current, 3)
 
-    def test_PrependFrames(self):
+    def test_AppendFrames(self):
         """Check that a concatenated FrameSet preserves all Frames.
         """
         set1 = self.makeFrameSet(1, 3)
@@ -76,7 +76,7 @@ class TestFrameSetPrepend(unittest.TestCase):
         # but let's make sure
         set1.removeFrame(2)
         set2 = self.makeFrameSet(3, 2)
-        set12 = prepend(set2, set1)
+        set12 = append(set1, set2)
 
         self.assertEquals(set1.nFrame + set2.nFrame,
                           set12.nFrame)
@@ -100,13 +100,13 @@ class TestFrameSetPrepend(unittest.TestCase):
             else:
                 self.assertFalse(offset + i == set12.current)
 
-    def test_PrependIndependent(self):
+    def test_AppendIndependent(self):
         """Check that a concatenated FrameSet is not affected by changes
         to its constituents.
         """
         set1 = self.makeFrameSet(3, 3)
         set2 = self.makeFrameSet(3, 3)
-        set12 = prepend(set2, set1)
+        set12 = append(set1, set2)
 
         nTotal = set12.nFrame
         x = [1.2, 3.4, 5.6]
@@ -122,14 +122,14 @@ class TestFrameSetPrepend(unittest.TestCase):
         self.assertEquals(set12.nFrame, nTotal)
         self.assertEquals(set12.tranForward(x), y)
 
-    def test_PrependMismatch(self):
-        """Check that prepend behaves as expected when joining non-identical frames.
+    def test_AppendMismatch(self):
+        """Check that append behaves as expected when joining non-identical frames.
         """
         set1 = self.makeFrameSet(3, 2)
         set2 = self.makeFrameSet(2, 3)
         set1.addFrame(FrameSet.CURRENT, makeForwardPolyMap(2, 2),
                       SkyFrame("Ident=sky"))
-        set12 = prepend(set2, set1)
+        set12 = append(set1, set2)
 
         x = [1.2, 3.4, 5.6]
         y_merged = set12.tranForward(x)

--- a/tests/test_chebyMap.py
+++ b/tests/test_chebyMap.py
@@ -500,7 +500,7 @@ class TestChebyMap(MappingTestCase):
         for i in range(1000):
             amap = astshim.ChebyMap(coeff_f, coeff_i, lbnd_f, ubnd_f, lbnd_i, ubnd_i)
             amapinv = amap.getInverse()
-            cmp2 = amap.of(amapinv)
+            cmp2 = amapinv.then(amap)
             result = cmp2.simplify()
             self.assertIsInstance(result, astshim.UnitMap)
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -181,7 +181,7 @@ class TestFrame(MappingTestCase):
     def test_FrameOver(self):
         frame1 = astshim.Frame(2, "label(1)=a, label(2)=b")
         frame2 = astshim.Frame(1, "label(1)=c")
-        cf = frame2.over(frame1)
+        cf = frame1.under(frame2)
         self.assertEqual(cf.nAxes, 3)
         self.assertEqual(cf.getLabel(1), "a")
         self.assertEqual(cf.getLabel(2), "b")

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -11,7 +11,7 @@ from astshim.test import MappingTestCase
 class TestMapping(MappingTestCase):
     """Test basics of Mapping
 
-    Note that Mapping.of and Mapping.over are tested by test_cmpMap.py
+    Note that Mapping.then and Mapping.under are tested by test_cmpMap.py
     """
 
     def setUp(self):

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -50,7 +50,7 @@ class TestObject(ObjectTestCase):
         # a deep copy does not increment
         self.assertEqual(obj.getRefCount(), 1)
 
-        seriesMap = obj.of(obj)
+        seriesMap = obj.then(obj)
         # obj itself plus two copies in the SeriesMap
         self.assertEqual(obj.getRefCount(), 3)
         del seriesMap

--- a/tests/test_polyMap.py
+++ b/tests/test_polyMap.py
@@ -295,7 +295,7 @@ class TestPolyMap(MappingTestCase):
         for i in range(1000):
             amap = astshim.PolyMap(coeff_f, coeff_i)
             amapinv = amap.getInverse()
-            cmp2 = amap.of(amapinv)
+            cmp2 = amapinv.then(amap)
             result = cmp2.simplify()
             self.assertIsInstance(result, astshim.UnitMap)
 

--- a/tests/test_unitNormMap.py
+++ b/tests/test_unitNormMap.py
@@ -85,7 +85,7 @@ class TestUnitNormMap(MappingTestCase):
             (unm1inv, winmap_unitscale, "UnitNormMap"),
             (unm1inv, winmap_notunitscale, "SeriesMap"),
         ):
-            cmpmap = map2.of(map1)
+            cmpmap = map1.then(map2)
             self.assertEqual(map1.nIn, cmpmap.nIn)
             self.assertEqual(map2.nOut, cmpmap.nOut)
             cmpmap_simp = cmpmap.simplify()


### PR DESCRIPTION
and `Mapping::over(first)` and `Frame::over(first)` to `under(next)`, to improve readability and match the constructor order of `SeriesMap`, `ParallelMap` and `CmpFrame`.