### PR TITLE
DM-19674: Channel: check error status from astRead

### DIFF
--- a/src/Channel.cc
+++ b/src/Channel.cc
@@ -49,6 +49,7 @@ Channel::~Channel() {
 
 std::shared_ptr<Object> Channel::read() {
     AstObject *rawRet = reinterpret_cast<AstObject *>(astRead(getRawPtr()));
+    assertOK(rawRet);
     if (!rawRet) {
         throw std::runtime_error("Could not read an AST object from this channel");
     }


### PR DESCRIPTION
If the error status isn't checked, it can deceive us into thinking it's
coming from somewhere else.