### PR TITLE
DM-19690: audit for ast error-checking

### DIFF
--- a/include/astshim/CmpFrame.h
+++ b/include/astshim/CmpFrame.h
@@ -74,7 +74,9 @@ public:
     explicit CmpFrame(Frame const &frame1, Frame const &frame2, std::string const &options = "")
             : Frame(reinterpret_cast<AstFrame *>(astCmpFrame(const_cast<AstObject *>(frame1.getRawPtr()),
                                                              const_cast<AstObject *>(frame2.getRawPtr()),
-                                                             "%s", options.c_str()))) {}
+                                                             "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~CmpFrame() {}
 

--- a/include/astshim/CmpMap.h
+++ b/include/astshim/CmpMap.h
@@ -77,7 +77,9 @@ public:
     explicit CmpMap(Mapping const &map1, Mapping const &map2, bool series, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(astCmpMap(const_cast<AstObject *>(map1.getRawPtr()),
                                                                const_cast<AstObject *>(map2.getRawPtr()),
-                                                               series, "%s", options.c_str()))) {}
+                                                               series, "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~CmpMap() {}
 

--- a/include/astshim/Frame.h
+++ b/include/astshim/Frame.h
@@ -166,7 +166,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit Frame(int naxes, std::string const &options = "")
-            : Mapping(reinterpret_cast<AstMapping *>(astFrame(naxes, "%s", options.c_str()))) {}
+            : Mapping(reinterpret_cast<AstMapping *>(astFrame(naxes, "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~Frame() {}
 

--- a/include/astshim/FrameSet.h
+++ b/include/astshim/FrameSet.h
@@ -115,7 +115,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit FrameSet(Frame const &frame, std::string const &options = "")
-            : FrameSet(astFrameSet(frame.copy()->getRawPtr(), "%s", options.c_str())) {}
+            : FrameSet(astFrameSet(frame.copy()->getRawPtr(), "%s", options.c_str())) {
+        assertOK();
+    }
 
     /**
     Construct a FrameSet from two frames and a mapping that connects them

--- a/include/astshim/KeyMap.h
+++ b/include/astshim/KeyMap.h
@@ -91,7 +91,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit KeyMap(std::string const &options = "")
-            : Object(reinterpret_cast<AstObject *>(astKeyMap("%s", options.c_str()))) {}
+            : Object(reinterpret_cast<AstObject *>(astKeyMap("%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~KeyMap(){};
 

--- a/include/astshim/LutMap.h
+++ b/include/astshim/LutMap.h
@@ -74,7 +74,9 @@ public:
     */
     explicit LutMap(std::vector<double> const &lut, double start, double inc, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
-                      astLutMap(lut.size(), lut.data(), start, inc, "%s", options.c_str()))) {}
+                      astLutMap(lut.size(), lut.data(), start, inc, "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~LutMap() {}
 

--- a/include/astshim/MathMap.h
+++ b/include/astshim/MathMap.h
@@ -376,7 +376,9 @@ public:
             std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(astMathMap(nin, nout, fwd.size(), getCStrVec(fwd).data(),
                                                                 rev.size(), getCStrVec(rev).data(), "%s",
-                                                                options.c_str()))) {}
+                                                                options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~MathMap() {}
 

--- a/include/astshim/MatrixMap.h
+++ b/include/astshim/MatrixMap.h
@@ -57,7 +57,9 @@ public:
             : Mapping(reinterpret_cast<AstMapping *>(
                       // form 0 = full matrix, 1 = diagonal elements only
                       astMatrixMap(matrix.getSize<1>(), matrix.getSize<0>(), 0, matrix.getData(), "%s",
-                                   options.c_str()))) {}
+                                   options.c_str()))) {
+        assertOK();
+    }
 
     /**
     Construct a MatrixMap from a 1-d vector of diagonal elements of a diagonal matrix
@@ -71,7 +73,9 @@ public:
     explicit MatrixMap(std::vector<double> const &diag, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
                       // form 0 = full matrix, 1 = diagonal elements only
-                      astMatrixMap(diag.size(), diag.size(), 1, diag.data(), "%s", options.c_str()))) {}
+                      astMatrixMap(diag.size(), diag.size(), 1, diag.data(), "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~MatrixMap() {}
 

--- a/include/astshim/NormMap.h
+++ b/include/astshim/NormMap.h
@@ -60,7 +60,9 @@ public:
     */
     explicit NormMap(Frame const &frame, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
-                      astNormMap(const_cast<AstObject *>(frame.getRawPtr()), "%s", options.c_str()))) {}
+                      astNormMap(const_cast<AstObject *>(frame.getRawPtr()), "%s", options.c_str()))) {
+                          assertOK();
+                      }
 
     virtual ~NormMap() {}
 

--- a/include/astshim/Object.h
+++ b/include/astshim/Object.h
@@ -87,6 +87,7 @@ public:
     */
     static std::shared_ptr<Object> fromString(std::string const &str) {
         auto *rawPtr = reinterpret_cast<AstObject *>(astFromString(str.c_str()));
+        assertOK(rawPtr);
         return Object::_basicFromAstObject(rawPtr);
     }
 
@@ -436,7 +437,10 @@ protected:
 
     @throws std::runtime_error if the attribute is read-only
     */
-    void set(std::string const &setting) { astSet(getRawPtr(), "%s", setting.c_str()); }
+    void set(std::string const &setting) {
+        astSet(getRawPtr(), "%s", setting.c_str());
+        assertOK();
+    }
 
     /**
     Set the value of an attribute as a bool

--- a/include/astshim/PcdMap.h
+++ b/include/astshim/PcdMap.h
@@ -135,7 +135,9 @@ private:
             os << "pcdcen.size() = " << pcdcen.size() << "; must be 2";
             throw std::invalid_argument(os.str());
         }
-        return astPcdMap(disco, pcdcen.data(), "%s", options.c_str());
+        auto result = astPcdMap(disco, pcdcen.data(), "%s", options.c_str());
+        assertOK();
+        return result;
     }
 };
 

--- a/include/astshim/RateMap.h
+++ b/include/astshim/RateMap.h
@@ -70,7 +70,9 @@ public:
     */
     explicit RateMap(Mapping const &map, int ax1, int ax2, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(astRateMap(const_cast<AstObject *>(map.getRawPtr()), ax1,
-                                                                ax2, "%s", options.c_str()))) {}
+                                                                ax2, "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~RateMap() {}
 

--- a/include/astshim/ShiftMap.h
+++ b/include/astshim/ShiftMap.h
@@ -48,7 +48,9 @@ public:
     */
     explicit ShiftMap(std::vector<double> const &shift, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
-                      astShiftMap(shift.size(), shift.data(), "%s", options.c_str()))) {}
+                      astShiftMap(shift.size(), shift.data(), "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~ShiftMap() {}
 

--- a/include/astshim/SkyFrame.h
+++ b/include/astshim/SkyFrame.h
@@ -122,7 +122,9 @@ public:
         systems.
     */
     explicit SkyFrame(std::string const &options = "")
-            : Frame(reinterpret_cast<AstFrame *>(astSkyFrame("%s", options.c_str()))) {}
+            : Frame(reinterpret_cast<AstFrame *>(astSkyFrame("%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~SkyFrame() {}
 
@@ -235,6 +237,7 @@ public:
     */
     std::shared_ptr<Mapping> skyOffsetMap() {
         auto *rawMap = reinterpret_cast<AstObject *>(astSkyOffsetMap(getRawPtr()));
+        assertOK();
         return Object::fromAstObject<Mapping>(rawMap, false);
     }
 

--- a/include/astshim/SphMap.h
+++ b/include/astshim/SphMap.h
@@ -61,7 +61,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit SphMap(std::string const &options = "")
-            : Mapping(reinterpret_cast<AstMapping *>(astSphMap("%s", options.c_str()))) {}
+            : Mapping(reinterpret_cast<AstMapping *>(astSphMap("%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~SphMap() {}
 

--- a/include/astshim/TimeFrame.h
+++ b/include/astshim/TimeFrame.h
@@ -87,7 +87,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit TimeFrame(std::string const &options = "")
-            : Frame(reinterpret_cast<AstFrame *>(astTimeFrame("%s", options.c_str()))) {}
+            : Frame(reinterpret_cast<AstFrame *>(astTimeFrame("%s", options.c_str()))) {
+                assertOK();
+            }
 
     virtual ~TimeFrame() {}
 
@@ -118,7 +120,11 @@ public:
         since the epoch `00:00:00 UTC 1 January 1970 AD` (equivalent to TAI with a constant offset).
     - Any inaccuracy in the system clock will be reflected in the value returned by this function.
     */
-    double currentTime() const { return detail::safeDouble(astCurrentTime(getRawPtr())); }
+    double currentTime() const {
+        auto result = detail::safeDouble(astCurrentTime(getRawPtr()));
+        assertOK();
+        return result;
+    }
 
     /// Get @ref TimeFrame_AlignTimeScale "AlignTimeScale": time scale in which to align TimeFrames.
     std::string getAlignTimeScale() const { return getC("AlignTimeScale"); }

--- a/include/astshim/TimeMap.h
+++ b/include/astshim/TimeMap.h
@@ -54,7 +54,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit TimeMap(std::string const &options = "")
-            : Mapping(reinterpret_cast<AstMapping *>(astTimeMap(0, "%s", options.c_str()))) {}
+            : Mapping(reinterpret_cast<AstMapping *>(astTimeMap(0, "%s", options.c_str()))) {
+                assertOK();
+            }
 
     virtual ~TimeMap() {}
 

--- a/include/astshim/TranMap.h
+++ b/include/astshim/TranMap.h
@@ -60,7 +60,9 @@ public:
     explicit TranMap(Mapping const &map1, Mapping const &map2, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(astTranMap(const_cast<AstObject *>(map1.getRawPtr()),
                                                                 const_cast<AstObject *>(map2.getRawPtr()),
-                                                                "%s", options.c_str()))) {}
+                                                                "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~TranMap() {}
 

--- a/include/astshim/UnitMap.h
+++ b/include/astshim/UnitMap.h
@@ -52,7 +52,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit UnitMap(int ncoord, std::string const &options = "")
-            : Mapping(reinterpret_cast<AstMapping *>(astUnitMap(ncoord, "%s", options.c_str()))) {}
+            : Mapping(reinterpret_cast<AstMapping *>(astUnitMap(ncoord, "%s", options.c_str()))) {
+                assertOK();
+            }
 
     virtual ~UnitMap() {}
 

--- a/include/astshim/UnitNormMap.h
+++ b/include/astshim/UnitNormMap.h
@@ -65,7 +65,9 @@ public:
     */
     explicit UnitNormMap(std::vector<double> const &centre, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
-                      astUnitNormMap(centre.size(), centre.data(), "%s", options.c_str()))) {}
+                      astUnitNormMap(centre.size(), centre.data(), "%s", options.c_str()))) {
+                          assertOK();
+                      }
 
     virtual ~UnitNormMap() {}
 

--- a/include/astshim/WcsMap.h
+++ b/include/astshim/WcsMap.h
@@ -208,7 +208,9 @@ public:
     */
     explicit WcsMap(int ncoord, WcsType type, int lonax, int latax, std::string const &options = "")
             : Mapping(reinterpret_cast<AstMapping *>(
-                      astWcsMap(ncoord, static_cast<int>(type), lonax, latax, "%s", options.c_str()))) {}
+                      astWcsMap(ncoord, static_cast<int>(type), lonax, latax, "%s", options.c_str()))) {
+        assertOK();
+    }
 
     virtual ~WcsMap() {}
 

--- a/include/astshim/WinMap.h
+++ b/include/astshim/WinMap.h
@@ -108,8 +108,10 @@ private:
             os << "outb.size() = " << outb.size() << " != " << ncoord << " = ina.size()";
             throw std::invalid_argument(os.str());
         }
-        return astWinMap(static_cast<int>(ncoord), ina.data(), inb.data(), outa.data(), outb.data(), "%s",
-                         options.c_str());
+        auto result = astWinMap(static_cast<int>(ncoord), ina.data(), inb.data(), outa.data(),
+                                outb.data(), "%s", options.c_str());
+        assertOK();
+        return result;
     }
 };
 

--- a/include/astshim/XmlChan.h
+++ b/include/astshim/XmlChan.h
@@ -58,7 +58,9 @@ public:
     explicit XmlChan(Stream &stream, std::string const &options = "")
             : Channel(reinterpret_cast<AstChannel *>(
                               astXmlChan(detail::source, detail::sink, "%s", options.c_str())),
-                      stream) {}
+                      stream) {
+        assertOK();
+    }
 
     virtual ~XmlChan() {}
 

--- a/include/astshim/ZoomMap.h
+++ b/include/astshim/ZoomMap.h
@@ -59,7 +59,9 @@ public:
     @param[in] options  Comma-separated list of attribute assignments.
     */
     explicit ZoomMap(int ncoord, double zoom, std::string const &options = "")
-            : Mapping(reinterpret_cast<AstMapping *>(astZoomMap(ncoord, zoom, "%s", options.c_str()))) {}
+            : Mapping(reinterpret_cast<AstMapping *>(astZoomMap(ncoord, zoom, "%s", options.c_str()))) {
+                assertOK();
+            }
 
     virtual ~ZoomMap() {}
 

--- a/include/astshim/detail/utils.h
+++ b/include/astshim/detail/utils.h
@@ -40,6 +40,7 @@ static const int FITSLEN = 80;
 inline void annulAstObject(AstObject *object) {
     if (object != nullptr) {
         astAnnul(object);
+        assertOK();
     }
 }
 

--- a/src/Channel.cc
+++ b/src/Channel.cc
@@ -29,7 +29,9 @@
 namespace ast {
 
 Channel::Channel(Stream &stream, std::string const &options)
-        : Channel(astChannel(detail::source, detail::sink, "%s", options.c_str()), stream) {}
+        : Channel(astChannel(detail::source, detail::sink, "%s", options.c_str()), stream) {
+    assertOK();
+}
 
 Channel::Channel(AstChannel *chan, Stream &stream, bool isFits)
         : Object(reinterpret_cast<AstObject *>(chan)), _stream(stream) {

--- a/src/ChebyMap.cc
+++ b/src/ChebyMap.cc
@@ -114,9 +114,12 @@ AstChebyMap *ChebyMap::_makeRawChebyMap(ConstArray2D const &coeff_f, ConstArray2
                             "number of output axes");
     }
 
-    return reinterpret_cast<AstChebyMap *>(astChebyMap(nin, nout, ncoeff_f, coeff_f.getData(), ncoeff_i,
-                                                       coeff_i.getData(), lbnd_f.data(), ubnd_f.data(),
-                                                       lbnd_i.data(), ubnd_i.data(), "%s", options.c_str()));
+    auto result = reinterpret_cast<AstChebyMap *>(astChebyMap(nin, nout, ncoeff_f, coeff_f.getData(),
+                                                              ncoeff_i, coeff_i.getData(), lbnd_f.data(),
+                                                              ubnd_f.data(), lbnd_i.data(), ubnd_i.data(),
+                                                              "%s", options.c_str()));
+    assertOK();
+    return result;
 }
 
 /// Make a raw AstChebyMap with a specified forward transform and an optional iterative inverse.

--- a/src/FitsChan.cc
+++ b/src/FitsChan.cc
@@ -44,13 +44,16 @@ char const *cstrOrNull(std::string const &str) { return str.empty() ? nullptr : 
 FitsChan::FitsChan(Stream &stream, std::string const &options)
         : Channel(reinterpret_cast<AstChannel *>(
                           astFitsChan(detail::source, detail::sink, "%s", options.c_str())),
-                  stream, true) {}
+                  stream, true) {
+    assertOK();
+}
 
 FitsChan::~FitsChan() {
     // when an astFitsChan is destroyed it first writes out any cards, but if I let astFitsChan
     // do this automatically then it occurs while the Channel and its Source are being destroyed,
     // which is too late
     astWriteFits(getRawPtr());
+    // No 'assertOK' here: can't throw in a Dtor.
 }
 
 FoundValue<std::complex<double>> FitsChan::getFitsCF(std::string const &name,

--- a/src/Mapping.cc
+++ b/src/Mapping.cc
@@ -53,10 +53,10 @@ Array2D Mapping::linearApprox(PointD const &lbnd, PointD const &ubnd, double tol
     detail::assertEqual(ubnd.size(), "ubnd.size", static_cast<std::size_t>(nIn), "nIn");
     Array2D fit = ndarray::allocate(ndarray::makeVector(1 + nIn, nOut));
     int isOK = astLinearApprox(getRawPtr(), lbnd.data(), ubnd.data(), tol, fit.getData());
+    assertOK();
     if (!isOK) {
         throw std::runtime_error("Mapping not sufficiently linear");
     }
-    assertOK();
     return fit;
 }
 
@@ -74,6 +74,7 @@ std::shared_ptr<Class> Mapping::decompose(int i, bool copy) const {
     AstMapping *rawMap2;
     int series, invert1, invert2;
     astDecompose(getRawPtr(), &rawMap1, &rawMap2, &series, &invert1, &invert2);
+    assertOK();
 
     if (!rawMap2) {
         // Not a compound object; free rawMap1 (rawMap2 is null, so no need to free it) and throw an exception
@@ -95,12 +96,14 @@ std::shared_ptr<Class> Mapping::decompose(int i, bool copy) const {
     }
     astAnnul(reinterpret_cast<AstObject *>(rawMap1));
     astAnnul(reinterpret_cast<AstObject *>(rawMap2));
+    assertOK();
 
     // If the mapping's internal invert flag does not match the value used when the CmpMap was made
     // then invert the mapping. Note that it is not possible to create such objects in astshim
     // but it is possible to read in objects created by other software.
     if (invert != astGetI(retRawMap, "Invert")) {
         astInvert(retRawMap);
+        assertOK();
     }
 
     return Object::fromAstObject<Class>(reinterpret_cast<AstObject *>(retRawMap), copy);

--- a/src/PermMap.cc
+++ b/src/PermMap.cc
@@ -67,8 +67,10 @@ AstPermMap* PermMap::makeRawMap(std::vector<int> const& inperm, std::vector<int>
     checkConstant(constant.size(), outperm, "outperm");
 
     double const* constptr = constant.size() > 0 ? constant.data() : nullptr;
-    return astPermMap(inperm.size(), inperm.data(), outperm.size(), outperm.data(), constptr, "%s",
-                      options.c_str());
+    auto result = astPermMap(inperm.size(), inperm.data(), outperm.size(), outperm.data(), constptr, "%s",
+                             options.c_str());
+    assertOK();
+    return result;
 }
 
 }  // namespace ast

--- a/src/PolyMap.cc
+++ b/src/PolyMap.cc
@@ -80,8 +80,10 @@ AstPolyMap *PolyMap::_makeRawPolyMap(ConstArray2D const &coeff_f, ConstArray2D c
         throw std::invalid_argument(os.str());
     }
 
-    return astPolyMap(nin, nout, ncoeff_f, coeff_f.getData(), ncoeff_i, coeff_i.getData(), "%s",
-                      options.c_str());
+    auto result = astPolyMap(nin, nout, ncoeff_f, coeff_f.getData(), ncoeff_i, coeff_i.getData(), "%s",
+                             options.c_str());
+    assertOK();
+    return result;
 }
 
 /// Make a raw AstPolyMap with a specified forward transform and an optional iterative inverse.
@@ -104,7 +106,9 @@ AstPolyMap *PolyMap::_makeRawPolyMap(ConstArray2D const &coeff_f, int nout,
         throw std::invalid_argument(os.str());
     }
 
-    return astPolyMap(nin, nout, ncoeff_f, coeff_f.getData(), 0, nullptr, "%s", options.c_str());
+    auto result = astPolyMap(nin, nout, ncoeff_f, coeff_f.getData(), 0, nullptr, "%s", options.c_str());
+    assertOK();
+    return result;
 }
 
 }  // namespace ast

--- a/src/QuadApprox.cc
+++ b/src/QuadApprox.cc
@@ -37,6 +37,7 @@ QuadApprox::QuadApprox(Mapping const& map, std::vector<double> const& lbnd, std:
     detail::assertEqual(ubnd.size(), "ubnd.size", static_cast<std::size_t>(nIn), "nIn");
     fit.reserve(6 * map.getNOut());
     bool isok = astQuadApprox(map.getRawPtr(), lbnd.data(), ubnd.data(), nx, ny, fit.data(), &rms);
+    assertOK();
     if (!isok) {
         throw std::runtime_error("Failed to fit a quadratic approximation");
     }


### PR DESCRIPTION
Added assertOK() where it had been left out. This is C code, so
it needs to be done after every astXXX function call, except for
a few (e.g., astAnnul) and where it's in a destructor. Otherwise,
the ast global error state can be set, we don't realise it, and
the error appears to come out of somewhere else.