### PR TITLE
DM-26871: Support new ShiftMap simplifications

### DIFF
--- a/include/astshim/base.h
+++ b/include/astshim/base.h
@@ -144,6 +144,10 @@ inline bool escapes(int include = -1) {
     return ret;
 }
 
+inline int version(void) {
+  return astVersion;
+}
+
 }  // namespace ast
 
 #endif

--- a/include/astshim/base.h
+++ b/include/astshim/base.h
@@ -144,7 +144,7 @@ inline bool escapes(int include = -1) {
     return ret;
 }
 
-inline int version(void) {
+inline int ast_version(void) {
   return astVersion;
 }
 

--- a/python/astshim/base.cc
+++ b/python/astshim/base.cc
@@ -34,6 +34,7 @@ namespace {
 PYBIND11_MODULE(base, mod) {
     mod.def("assertOK", &assertOK, "rawObj1"_a = nullptr, "rawObj2"_a = nullptr);
     mod.def("escapes", &escapes, "include"_a = -1);
+    mod.def("version", &version);
 
     // Make a deep copy to avoid memory issues in Python
     mod.def("arrayFromVector", [](std::vector<double> const& data, int nAxes) {

--- a/python/astshim/base.cc
+++ b/python/astshim/base.cc
@@ -34,7 +34,7 @@ namespace {
 PYBIND11_MODULE(base, mod) {
     mod.def("assertOK", &assertOK, "rawObj1"_a = nullptr, "rawObj2"_a = nullptr);
     mod.def("escapes", &escapes, "include"_a = -1);
-    mod.def("version", &version);
+    mod.def("astVersion", &ast_version);
 
     // Make a deep copy to avoid memory issues in Python
     mod.def("arrayFromVector", [](std::vector<double> const& data, int nAxes) {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,7 +33,7 @@ class TestBase(ObjectTestCase):
                 ast.arrayFromVector(vec=badDataVec, nAxes=nAxes)
 
     def testVersion(self):
-        version = ast.version()
+        version = ast.astVersion()
         self.assertGreaterEqual(version, 9001000)
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -32,6 +32,10 @@ class TestBase(ObjectTestCase):
             with self.assertRaises(RuntimeError):
                 ast.arrayFromVector(vec=badDataVec, nAxes=nAxes)
 
+    def testVersion(self):
+        version = ast.version()
+        self.assertGreaterEqual(version, 9001000)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_unitNormMap.py
+++ b/tests/test_unitNormMap.py
@@ -88,8 +88,13 @@ class TestUnitNormMap(MappingTestCase):
         winmap_notunitscale = ast.WinMap(
             np.zeros(3), shift, np.ones(3), np.ones(3) * 2 + shift)
 
+        if ast.astVersion() >= 9001003:
+            expected_map = "ShiftMap"  # ShiftMap is ShiftMap in 9.1.3
+        else:
+            expected_map = "WinMap"  # ShiftMap gets simplified to WinMap
+
         for map1, map2, pred_simplified_class_name in (
-            (unm1, unm2inv, "WinMap"),  # ShiftMap gets simplified to WinMap
+            (unm1, unm2inv, expected_map),
             (shiftmap, unm1, "UnitNormMap"),
             (winmap_unitscale, unm1, "UnitNormMap"),
             (winmap_notunitscale, unm1, "SeriesMap"),


### PR DESCRIPTION
Newer versions of astshim (since 9.1.3) simplify ShiftMaps to ShiftMaps.